### PR TITLE
Secondary lables not visible.

### DIFF
--- a/resources/less/forum/extension.less
+++ b/resources/less/forum/extension.less
@@ -516,7 +516,7 @@ body.dark {
 
     .TagLabel {
         background: @control-bg;
-        color: @control-color;
+        color: white;
 
         &.untagged {
             border: 1px dotted @muted-color;


### PR DESCRIPTION
This commit 9aa73fa fixes the minor issue of secondary labels being non-visible with certain darker backgrounds.

![image](https://user-images.githubusercontent.com/53521400/73156381-a8beb800-4103-11ea-95d5-2a651c6e08f2.png)
