### PR TITLE
Fix Colors for Avatar Background & Modal Header

### DIFF
--- a/resources/less/forum/extension.less
+++ b/resources/less/forum/extension.less
@@ -486,6 +486,13 @@ body.dark {
     .Modal-header {
         background: @control-bg;
     }
+	
+	@media @phone {
+		.ModalManager:before {
+			background: fade(@header-bg, 98%);
+			border-color: @control-bg;
+		}
+	}
 
     /*
     * — Slidable —

--- a/resources/less/forum/extension.less
+++ b/resources/less/forum/extension.less
@@ -487,12 +487,12 @@ body.dark {
         background: @control-bg;
     }
 	
-	@media @phone {
-		.ModalManager:before {
-			background: fade(@header-bg, 98%);
-			border-color: @control-bg;
-		}
-	}
+    @media @phone {
+	    .ModalManager:before {
+		    background: fade(@header-bg, 98%);
+		    border-color: @control-bg;
+	    }
+    }
 
     /*
     * — Slidable —

--- a/resources/less/forum/extension.less
+++ b/resources/less/forum/extension.less
@@ -115,6 +115,10 @@ body.dark {
     .App:before {
         background: fade(@header-bg, 98%);
     }
+	
+    .Avatar {
+        background-color: @control-bg;
+    }
 
     .Form-group > label {
         color: @text-color;


### PR DESCRIPTION
**Fixes:**

![](https://i.ibb.co/Mn3YKs8/fix-avatars.png)

There is a tiny greyish border on avatars' frame because of wrong background color. Here's the related line on flarum/core:

https://github.com/flarum/core/blob/cbe328cdc594405d08fee74004b7f343ce4c73fb/less/common/Avatar.less#L7

**Fixes:**

![](https://i.ibb.co/fS2Rrk1/fix-modals.png)

Modals' header turns greyish on mobile view (you can check "Change Password" modal to reproduce). Here's the related line on flarum/core:

https://github.com/flarum/core/blob/9c0d921f49e049d4374ad666f065089521ef76a5/less/common/Modal.less#L154