### PR TITLE
Remove !important because it's not needed

### DIFF
--- a/resources/less/forum/extension.less
+++ b/resources/less/forum/extension.less
@@ -535,7 +535,7 @@ body.dark {
 
         &.colored {
             .TagLabel-text {
-                color: @body-bg !important;
+                color: @body-bg;
             }
         }
     }


### PR DESCRIPTION
Remove !important for "TagLabel-text " because it's not needed and additional changing force you to hack the theme with animations.

I did not remove others because for now they do not force me to hack them. 