### PR TITLE
Fix flash of unstyled content when switching from Auto to a specific theme

### DIFF
--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -15,17 +15,18 @@ function populateThemes() {
 }
 
 app.initializers.add('fof-nightmode', () => {
-    app.extensionData.for('fof-nightmode')
-    .registerSetting({
-        label: app.translator.trans('fof-nightmode.admin.settings.modal.default_theme'),
-        setting: 'fof-nightmode.default_theme',
-        type: 'select',
-        options: populateThemes()
-    })
-    .registerSetting({
-        label: app.translator.trans('fof-nightmode.admin.settings.modal.default_theme_helper'),
-        type: 'hidden',
-    });
-    
+    app.extensionData
+        .for('fof-nightmode')
+        .registerSetting({
+            label: app.translator.trans('fof-nightmode.admin.settings.modal.default_theme'),
+            setting: 'fof-nightmode.default_theme',
+            type: 'select',
+            options: populateThemes(),
+        })
+        .registerSetting({
+            label: app.translator.trans('fof-nightmode.admin.settings.modal.default_theme_helper'),
+            type: 'hidden',
+        });
+
     setSelectedTheme();
 });

--- a/js/src/common/setSelectedTheme.js
+++ b/js/src/common/setSelectedTheme.js
@@ -55,13 +55,30 @@ export function setStyle(type) {
     if (light && dark) {
         if (getTheme() === Themes.AUTO) return;
 
-        const el = type === 'day' ? dark : light;
-        const current = type === 'day' ? light : dark;
+        let newLink = document.createElement('link');
 
-        el.remove();
+        // onload on link tags not supported in all browsers
+        // so we should check it is present in the user's
+        // current browser
+        if ('onload' in newLink) {
+            // if it is, only remove the old link tags after the new
+            // one has finished loading (prevents flash of unstyled
+            // content)
+            newLink.onload = function () {
+                light.remove();
+                dark.remove();
+            };
+        } else {
+            // if it isn't, just remove the old link tags immediately
+            light.remove();
+            dark.remove();
+        }
 
-        current.setAttribute('media', '');
-        current.className = 'nightmode';
+        newLink.rel = 'stylesheet';
+        newLink.className = 'nightmode';
+        newLink.href = getUrls()[type];
+
+        document.head.append(newLink);
     } else {
         const el = light || dark || document.querySelector('link.nightmode[rel=stylesheet]');
 

--- a/js/src/common/setSelectedTheme.js
+++ b/js/src/common/setSelectedTheme.js
@@ -53,7 +53,7 @@ export function setStyle(type) {
     const dark = document.querySelector('link.nightmode-dark[rel=stylesheet]');
 
     if (light && dark) {
-        if (getTheme() === 0) return;
+        if (getTheme() === Themes.AUTO) return;
 
         const el = type === 'day' ? dark : light;
         const current = type === 'day' ? light : dark;


### PR DESCRIPTION
Most browsers don't download CSS files with `media` attributes that don't apply to the current rendering context. Because of this, when the original link tag is removed, there is no CSS styling for the page for a split second (or multiple seconds on a slower connection).

Instead of immediately removing the old `link` tag, we now add a brand new link to the desired CSS, along with an `onload` event handler. This way we only remove the old `link`s after the new theme CSS has been loaded.

Using `onload` on the existing (but not used) `link` doesn't seem to work (at least in Chrome) as the even never gets triggered.

## Before

![Animated GIF of unstyled content](https://user-images.githubusercontent.com/7406822/102728245-9b657a00-4322-11eb-9ab5-496a31faaa21.gif)

## After

![Animated GIF of fixed unstyled content](https://user-images.githubusercontent.com/7406822/102728275-d2d42680-4322-11eb-920d-09b8bea2c361.gif)
