### PR TITLE
fix: auto applies both stylesheets instead of only the applicable one

### DIFF
--- a/src/Content/Assets.php
+++ b/src/Content/Assets.php
@@ -70,7 +70,7 @@ class Assets extends \Flarum\Frontend\Content\Assets
     {
         return sprintf(
             '<link rel="stylesheet" media="%s" class="nightmode-%s" href="%s" />',
-            $auto && $type === 'dark' ? '(prefers-color-scheme: dark)' : '',
+            $auto && $type === 'dark' ? '(prefers-color-scheme: dark)' : '(prefers-color-scheme: light), (prefers-color-scheme: no-preference)',
             $type,
             $url
         );

--- a/src/Content/Assets.php
+++ b/src/Content/Assets.php
@@ -70,7 +70,7 @@ class Assets extends \Flarum\Frontend\Content\Assets
     {
         return sprintf(
             '<link rel="stylesheet" media="%s" class="nightmode-%s" href="%s" />',
-            $auto && $type === 'dark' ? '(prefers-color-scheme: dark)' : '(prefers-color-scheme: light), (prefers-color-scheme: no-preference)',
+            $auto && $type === 'dark' ? '(prefers-color-scheme: dark)' : 'not all and (prefers-color-scheme: dark)',
             $type,
             $url
         );


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
`@config-dark-mode` doesn't always act as expected.

For example, the following Less would apply on light, auto light and auto dark mode, when you'd expect it to only run in light and auto light mode:
```less
#app when (@config-dark-mode = false) {
    display: none;
}
```

This is because the light and dark stylesheets are applied when in auto mode instead of only the applicable stylesheet. This was introduced in 6e683ea30d5a6988f12c982bcdeb89872b9196eb.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
