### PR TITLE
fix: no css loading when using 'auto' and device does not support `prefers-color-scheme`

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -17,13 +17,17 @@ use FoF\Extend\Extend as FoFExtend;
 
 return [
     (new Extend\Frontend('forum'))
-        ->js(__DIR__.'/js/dist/forum.js')
-        ->content(Content\HideBody::class),
-    (new Extend\Frontend('admin'))
-        ->js(__DIR__.'/js/dist/admin.js')
-        ->content(Content\HideBody::class),
+        ->js(__DIR__ . '/js/dist/forum.js')
+        ->content(Content\HideBody::class)
+        ->content(Content\PatchUnsupportedAutoNightmode::class)
+        ->css(__DIR__ . '/resources/less/forum.less'),
 
-    new Extend\Locales(__DIR__.'/resources/locale'),
+    (new Extend\Frontend('admin'))
+        ->js(__DIR__ . '/js/dist/admin.js')
+        ->content(Content\HideBody::class)
+        ->content(Content\PatchUnsupportedAutoNightmode::class),
+
+    new Extend\Locales(__DIR__ . '/resources/locale'),
 
     (new FoFExtend\ExtensionSettings())
         ->addKey('fof-nightmode.default_theme'),
@@ -40,4 +44,16 @@ return [
             return (int) $value;
         })
         ->registerPreference('fofNightMode_perDevice', null, false),
+
+    (new Extend\Settings())
+        ->serializeToForum('fofNightMode_autoUnsupportedFallback', 'theme_dark_mode', function ($val) {
+            $val = (bool) $val;
+
+            // 2 = night mode, 1 = light mode, 0 = auto
+            if ($val) {
+                return 2;
+            }
+
+            return 1;
+        }, false),
 ];

--- a/extend.php
+++ b/extend.php
@@ -17,17 +17,17 @@ use FoF\Extend\Extend as FoFExtend;
 
 return [
     (new Extend\Frontend('forum'))
-        ->js(__DIR__ . '/js/dist/forum.js')
+        ->js(__DIR__.'/js/dist/forum.js')
         ->content(Content\HideBody::class)
         ->content(Content\PatchUnsupportedAutoNightmode::class)
-        ->css(__DIR__ . '/resources/less/forum.less'),
+        ->css(__DIR__.'/resources/less/forum.less'),
 
     (new Extend\Frontend('admin'))
-        ->js(__DIR__ . '/js/dist/admin.js')
+        ->js(__DIR__.'/js/dist/admin.js')
         ->content(Content\HideBody::class)
         ->content(Content\PatchUnsupportedAutoNightmode::class),
 
-    new Extend\Locales(__DIR__ . '/resources/locale'),
+    new Extend\Locales(__DIR__.'/resources/locale'),
 
     (new FoFExtend\ExtensionSettings())
         ->addKey('fof-nightmode.default_theme'),

--- a/js/src/forum/addSettingsItems.js
+++ b/js/src/forum/addSettingsItems.js
@@ -28,7 +28,19 @@ export default function () {
       fixInvalidThemeSetting();
     }
 
-    const currentTheme = getTheme();
+    const doesNotSupportAuto = !window.matchMedia('not all and (prefers-color-scheme), (prefers-color-scheme)').matches;
+
+    let currentTheme = getTheme();
+
+    const options = { 0: trans('options.auto'), 1: trans('options.day'), 2: trans('options.night') };
+
+    if (doesNotSupportAuto) {
+      delete options['0'];
+
+      if (currentTheme === Themes.AUTO) {
+        currentTheme = app.forum.attribute('fofNightMode_autoUnsupportedFallback');
+      }
+    }
 
     items.add(
       'fof-nightmode',
@@ -40,6 +52,7 @@ export default function () {
         [
           <p className="description">{trans('description')}</p>,
           <p className="description">{trans('description2')}</p>,
+          doesNotSupportAuto ? <p class="description NightMode-autoUnsupported">{trans('auto_unsupported')}</p> : null,
           Switch.component(
             {
               className: 'Settings-theme--per_device_cb',
@@ -78,7 +91,7 @@ export default function () {
 
               user
                 .savePreferences({
-                  fofNightMode: Number.parseInt(e),
+                  fofNightMode: e,
                 })
                 .then(() => {
                   m.redraw();
@@ -88,7 +101,7 @@ export default function () {
                   setTheme();
                 });
             },
-            options: [trans('options.auto'), trans('options.day'), trans('options.night')],
+            options,
           }),
           <p className="Settings-theme--selection_description">
             {currentTheme === Themes.AUTO

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,0 +1,10 @@
+.NightMode-autoUnsupported {
+    @warning-color: #d98a14;
+
+    border-left: 4px solid @warning-color;
+    background: fade(@warning-color, 10%);
+
+    padding-left: 8px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -23,6 +23,7 @@ fof-nightmode:
                 description2: This theme will be linked to your account and applies to all your devices unless you toggle on the switch below for per device settings.
                 device_specific_setting_checkbox: Use per device settings
                 device_specific_setting_checkbox_tooltip: Your theme choice will be saved individually for each of your devices.
+                auto_unsupported: Your browser does not support auto dark mode.
                 options:
                     auto: => fof-nightmode.ref.auto
                     day: => fof-nightmode.ref.light

--- a/src/Content/PatchUnsupportedAutoNightmode.php
+++ b/src/Content/PatchUnsupportedAutoNightmode.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of fof/nightmode.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\NightMode\Content;
+
+use Flarum\Frontend\Document;
+use Flarum\Settings\SettingsRepositoryInterface;
+
+class PatchUnsupportedAutoNightmode
+{
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * @param Document $document
+     */
+    public function __invoke(Document $document)
+    {
+        // This JS snippet is a workaround for browsers which do not support the `prefers-color-scheme` CSS media query.
+        //
+        // For info about how the `matchmedia()` call works, see:
+        // https://kilianvalkhof.com/2021/web/detecting-media-query-support-in-css-and-javascript/#detecting-media-query-support-in-java-script
+
+        $class = $this->settings->get('theme_dark_mode', false) ? 'nightmode-dark' : 'nightmode-light';
+
+        $document->head[] = "
+        <script>
+            /* fof/nightmode workaround for browsers without (prefers-color-scheme) CSS media query support */
+            if (!window.matchMedia('not all and (prefers-color-scheme), (prefers-color-scheme)').matches) {
+                document.querySelector('link.$class').removeAttribute('media');
+            }
+        </script>
+        ";
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- no css loading when using 'auto' and device does not support `prefers-color-scheme`
- falls back to core's dark mode setting in this case ^
- removes 'auto' option on devices without support
- adds warning to user preferences when device does not support auto

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
