### PR TITLE
Add button for guests to toggle forum theme

### DIFF
--- a/js/src/common/setSelectedTheme.js
+++ b/js/src/common/setSelectedTheme.js
@@ -1,3 +1,5 @@
+import app from 'flarum/common/app';
+
 import { extend } from 'flarum/common/extend';
 import Page from 'flarum/common/components/Page';
 
@@ -12,13 +14,11 @@ export default () => {
 export function setTheme() {
   const { user } = app.session;
 
-  if (!user) {
-    // Default to automatic theme when visiting as guest
-    setThemeFromID(Themes.DEFAULT());
-    return;
-  }
+  const PerDevice = app.session.user?.preferences().fofNightMode_perDevice;
 
-  const PerDevice = user.preferences().fofNightMode_perDevice;
+  if (!user || PerDevice) {
+    fixInvalidThemeSetting();
+  }
 
   if (PerDevice) {
     fixInvalidThemeSetting();

--- a/js/src/forum/addSettingsItems.js
+++ b/js/src/forum/addSettingsItems.js
@@ -1,13 +1,15 @@
 import app from 'flarum/forum/app';
 import { extend } from 'flarum/common/extend';
 
-import SettingsPage from 'flarum/common/components/SettingsPage';
+import SettingsPage from 'flarum/forum/components/SettingsPage';
+import SessionDropdown from 'flarum/forum/components/SessionDropdown';
+import HeaderSecondary from 'flarum/forum/components/HeaderSecondary';
 import Button from 'flarum/common/components/Button';
-import SessionDropdown from 'flarum/common/components/SessionDropdown';
 import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
 import Select from 'flarum/common/components/Select';
 import FieldSet from 'flarum/common/components/FieldSet';
 import Switch from 'flarum/common/components/Switch';
+import icon from 'flarum/common/helpers/icon';
 
 import { setTheme } from '../common/setSelectedTheme';
 import fixInvalidThemeSetting from './fixInvalidThemeSetting';
@@ -17,6 +19,20 @@ import Themes from '../common/Themes';
 
 // custom function for translations makes it a lot cleaner
 const trans = (key) => app.translator.trans(`fof-nightmode.forum.user.settings.${key}`);
+
+const getIsLight = (theme) => theme === Themes.LIGHT || (theme === Themes.AUTO && !window.matchMedia('(prefers-color-scheme: dark)').matches);
+
+const toggleThrough = (current) => {
+  if (current === Themes.AUTO) {
+    return Themes.LIGHT;
+  }
+
+  if (current === Themes.LIGHT) {
+    return Themes.DARK;
+  }
+
+  return Themes.AUTO;
+};
 
 export default function () {
   extend(SettingsPage.prototype, 'settingsItems', function (items) {
@@ -118,12 +134,35 @@ export default function () {
     );
   });
 
+  extend(HeaderSecondary.prototype, 'items', function (items) {
+    if (app.session.user) return;
+
+    const theme = getTheme();
+    const isLight = getIsLight(theme);
+
+    items.add(
+      'nightmode',
+      <Button
+        className="Button Button--flat"
+        onclick={() => {
+          const newTheme = toggleThrough(theme);
+
+          perDevice.set(newTheme);
+          setTheme();
+        }}
+        icon={theme === Themes.AUTO ? 'fas fa-adjust' : `far fa-${isLight ? 'sun' : 'moon'}`}
+      >
+        {app.translator.trans('fof-nightmode.forum.header.nightmode_button')}
+      </Button>,
+      15
+    );
+  });
+
   extend(SessionDropdown.prototype, 'items', function (items) {
     if (!app.session.user) return;
 
     const user = app.session.user;
-    const theme = getTheme();
-    const isLight = theme === Themes.LIGHT || (theme === Themes.AUTO && !window.matchMedia('(prefers-color-scheme: dark)').matches);
+    const isLight = getIsLight(getTheme());
 
     // Add night mode link to session dropdown
     items.add(

--- a/js/src/forum/getTheme.js
+++ b/js/src/forum/getTheme.js
@@ -4,7 +4,7 @@ import { get } from './helpers/perDeviceSetting';
 export default function getTheme() {
   const user = app.session.user;
 
-  const IsUsingPerDeviceSettings = user && !!user.preferences().fofNightMode_perDevice;
+  const IsUsingPerDeviceSettings = !user || !!user.preferences().fofNightMode_perDevice;
   const SelectedTheme = user && user.preferences().fofNightMode;
 
   let value;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -14,3 +14,15 @@
         width: 100%;
     }
 }
+
+.Header-secondary .item-nightmode {
+    @media not @phone {
+        .Button-label {
+            display: none;
+        }
+
+        .Button-icon {
+            margin-right: 0;
+        }
+    }
+}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -16,6 +16,9 @@ fof-nightmode:
         day: => fof-nightmode.ref.light
         night: => fof-nightmode.ref.dark
 
+        header:
+            nightmode_button: Toggle forum theme
+
         user:
             settings:
                 heading: Theme


### PR DESCRIPTION
**Fixes #35**

**Changes proposed in this pull request:**
- Add button to HeaderSecondary for guests only

**Reviewers should focus on:**
- Button shows current theme because there are 3 options, showing the next one is more confusing

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/149243180-35409cbd-8609-4de8-a3a5-52910595349d.png)
![image](https://user-images.githubusercontent.com/6401250/149243189-ec093388-140d-48fd-a37e-b09205c929d4.png)
![image](https://user-images.githubusercontent.com/6401250/149243193-8442ff3e-c189-4c20-bf4b-cec82fef7b3f.png)
![image](https://user-images.githubusercontent.com/6401250/149243212-c6ccdabd-31dd-4a5c-9518-329f06bc7433.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
