### PR TITLE
Change MEDIAEMBED_THEME rendering parameter

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -15,6 +15,7 @@ use Flarum\Extend;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\DefaultUserPreferences\Extend\RegisterUserPreferenceDefault;
+use s9e\TextFormatter\Configurator;
 
 return [
     (new Extend\Frontend('forum'))
@@ -57,6 +58,13 @@ return [
         }, false)
         ->serializeToForum('fofNightMode.showThemeToggleOnHeaderAlways', 'fofNightMode.show_theme_toggle_on_header_always', 'boolval', false)
         ->serializeToForum('fof-nightmode.default_theme', 'fof-nightmode.default_theme', 'intval'),
+
+    (new Extend\Formatter())
+        ->configure(function (Configurator $configurator) {
+            if ((int) resolve('flarum.settings')->get('fof-nightmode.default_theme') === 2) {
+                $configurator->rendering->parameters['MEDIAEMBED_THEME'] = 'dark';
+            }
+        }),
 
     class_exists(RegisterUserPreferenceDefault::class) && resolve(ExtensionManager::class)->isEnabled('fof-default-user-preferences') ? (new RegisterUserPreferenceDefault())
         ->default('fofNightMode', 0, 'number')


### PR DESCRIPTION
This is more of a proof of concept because it's not really doing things the way we expect.

We should update the `MEDIAEMBED_THEME` rendering parameter based on the selected theme. Unfortunately I'm not sure we can change this value per-request in Flarum since the `Formatter::configure` extender only runs after a cache clear. There's also no way to access the actor or cookies from that extender so it would require additional code.

This PR is a working solution to always apply the default theme value as the MediaEmbed theme.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
