### PR TITLE
feat: dispatch event when setting the style

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ composer update fof/nightmode
 
 ### Integrating with `fof/nightmode` from another extension
 
-Each time the mode is switched from `day` to `night`, a `fofnightmodechange` event is dispatched. An extension can then listen to this event like so to react to this change:
+Each time the mode is switched from `day` to `night` (and vice versa), a `fofnightmodechange` event is dispatched. An extension can then listen to this event to react to this change, like so:
 
 ```js
 if (flarum.extensions['fof-nightmode']) {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ composer require fof/nightmode:"*"
 composer update fof/nightmode
 ```
 
+### Integrating with `fof/nightmode` from another extension
+
+Each time the mode is switched from `day` to `night`, a `fofnightmodechange` event is dispatched. An extension can then listen to this event like so to react to this change:
+
+```js
+if (flarum.extensions['fof-nightmode']) {
+  document.addEventListener('fofnightmodechange', (event) => {
+    if (event.detail == 'day') {
+      console.log('day mode');
+    } else {
+      console.log('night mode');
+    }
+  });
+}
+```
+
 ### Links
 
 [<img src="https://opencollective.com/fof/donate/button@2x.png?color=blue" height="25" />](https://opencollective.com/fof/donate)

--- a/js/src/common/setSelectedTheme.js
+++ b/js/src/common/setSelectedTheme.js
@@ -10,8 +10,11 @@ import getTheme from '../forum/getTheme';
 export default () => {
   extend(Page.prototype, 'oninit', setTheme);
 
-  const darkModePreference = window.matchMedia("(prefers-color-scheme: dark)");
-  darkModePreference.addEventListener("change", setTheme);
+  // Register setTheme() as the handler for 'prefers-color-scheme' media property
+  // change. This allows to make sure the 'fofnightmodechange' event is dispatched
+  // when this property changes, and that the correct stylesheets are loaded.
+  const prefersColorSchemeDark = window.matchMedia("(prefers-color-scheme: dark)");
+  prefersColorSchemeDark.addEventListener("change", setTheme);
 };
 
 export function setTheme() {
@@ -55,11 +58,8 @@ export function setStyle(type) {
   const light = document.querySelector('link.nightmode-light[rel=stylesheet]');
   const dark = document.querySelector('link.nightmode-dark[rel=stylesheet]');
 
-  const event = new CustomEvent("fofnightmodechange", { detail: type });
-  document.dispatchEvent(event);
-
-  if (light && dark) {
-    if (getTheme() === Themes.AUTO) return;
+  bothStyleSheets: if (light && dark) {
+    if (getTheme() === Themes.AUTO) break bothStyleSheets;
 
     let newLink = document.createElement('link');
 
@@ -95,4 +95,9 @@ export function setStyle(type) {
       el.className = 'nightmode';
     }
   }
+
+  // Dispatch a 'fofnightmodechange' event with 'day' or 'night' as detail.
+  // This allows other extensions to integrate with this one..
+  const event = new CustomEvent("fofnightmodechange", { detail: type });
+  document.dispatchEvent(event);
 }

--- a/js/src/common/setSelectedTheme.js
+++ b/js/src/common/setSelectedTheme.js
@@ -9,6 +9,9 @@ import getTheme from '../forum/getTheme';
 
 export default () => {
   extend(Page.prototype, 'oninit', setTheme);
+
+  const darkModePreference = window.matchMedia("(prefers-color-scheme: dark)");
+  darkModePreference.addEventListener("change", setTheme);
 };
 
 export function setTheme() {
@@ -51,6 +54,9 @@ export function setThemeFromID(theme) {
 export function setStyle(type) {
   const light = document.querySelector('link.nightmode-light[rel=stylesheet]');
   const dark = document.querySelector('link.nightmode-dark[rel=stylesheet]');
+
+  const event = new CustomEvent("fofnightmodechange", { detail: type });
+  document.dispatchEvent(event);
 
   if (light && dark) {
     if (getTheme() === Themes.AUTO) return;

--- a/js/src/common/setSelectedTheme.js
+++ b/js/src/common/setSelectedTheme.js
@@ -13,8 +13,8 @@ export default () => {
   // Register setTheme() as the handler for 'prefers-color-scheme' media property
   // change. This allows to make sure the 'fofnightmodechange' event is dispatched
   // when this property changes, and that the correct stylesheets are loaded.
-  const prefersColorSchemeDark = window.matchMedia("(prefers-color-scheme: dark)");
-  prefersColorSchemeDark.addEventListener("change", setTheme);
+  const prefersColorSchemeDark = window.matchMedia('(prefers-color-scheme: dark)');
+  prefersColorSchemeDark.addEventListener('change', setTheme);
 };
 
 export function setTheme() {
@@ -97,7 +97,7 @@ export function setStyle(type) {
   }
 
   // Dispatch a 'fofnightmodechange' event with 'day' or 'night' as detail.
-  // This allows other extensions to integrate with this one..
-  const event = new CustomEvent("fofnightmodechange", { detail: type });
+  // This allows other extensions to integrate with this one.
+  const event = new CustomEvent('fofnightmodechange', { detail: type });
   document.dispatchEvent(event);
 }


### PR DESCRIPTION
**Fixes #69**

**Changes proposed in this pull request:**

This allows other extension to simply listen to 'fofnightmodechange' event on document to adapt to a theme change.

```js
if (flarum.extensions['fof-nightmode']) {
  document.addEventListener('fofnightmodechange', (event) => {
    if (event.detail == 'day') {
      console.log('theme is light');
    } else {
      console.log('theme is dark');
    }
  });
}
```

From what I saw in the code, `setStyle(type)` is the function that gets call in the end by every theme switching function, so I choose to dispatch the event in this function. 
It is also convenient as the `type` variable already contains the style that will be applied so all we have to do is add it as the detail of the event.

~~Ideally I would have dispatched the event at the end of the function but due to the early return it was simpler to just dispatch it sooner. I can change this if you want.~~ EDIT: done using a [`break` statement with a labeled block](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label#using_a_labeled_block_with_break).


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.


**P.S.**

I didn't commit the changes of `/js/dist` to keep the patch simple.

**P.S. 2**

~~I can add a small example in the README once you are OK with the changes.~~ EDIT: Done.