### PR TITLE
Add classes to body for dark and light mode targeting

### DIFF
--- a/js/src/forum/helpers/switchTheme.ts
+++ b/js/src/forum/helpers/switchTheme.ts
@@ -25,6 +25,14 @@ export function switchTheme() {
   const isLight = getIsLight(theme);
   const user = app.session.user;
 
+  // Add classes to the body tag based on the theme
+  document.body.classList.remove('fof-DarkMode', 'fof-LightMode');
+  if (isLight) {
+      document.body.classList.add('fof-LightMode');
+  } else {
+      document.body.classList.add('fof-DarkMode');
+  }
+
   if (user) {
     const val = isLight ? Themes.DARK : Themes.LIGHT;
 


### PR DESCRIPTION

**Fixes #77**

**Changes proposed in this pull request:**
- Added `fof-DarkMode` and `fof-LightMode` classes to the `<body>` tag when switching themes in the `switchTheme.ts` file.
- This change allows for better targeting of styles specific to dark and light modes, improving readability and user experience.

**Reviewers should focus on:**
- The logic for adding and removing classes from the `<body>` tag.
- Ensuring that the changes do not affect existing functionality.
- Feedback on whether the class names align with the project's naming conventions.


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
